### PR TITLE
Update stake authorization typing

### DIFF
--- a/packages/proto/src/messages/authz/stake.ts
+++ b/packages/proto/src/messages/authz/stake.ts
@@ -5,20 +5,20 @@ export const stakeAuthTypes =
   authzStake.cosmos.staking.v1beta1.AuthorizationType
 
 export function createStakeAuthorization(
-  allowAddress: string,
-  denom: string,
-  maxTokens: string | undefined,
+  allowAddresses: string[] | undefined,
+  maxTokens: { denom: string; amount: string } | undefined,
   authorizationType: authzStake.cosmos.staking.v1beta1.AuthorizationType,
 ) {
   const msg = new authzStake.cosmos.staking.v1beta1.StakeAuthorization({
-    allow_list:
-      new authzStake.cosmos.staking.v1beta1.StakeAuthorization.Validators({
-        address: [allowAddress],
-      }),
+    allow_list: allowAddresses
+      ? new authzStake.cosmos.staking.v1beta1.StakeAuthorization.Validators({
+          address: allowAddresses,
+        })
+      : undefined,
     max_tokens: maxTokens
       ? new coin.cosmos.base.v1beta1.Coin({
-          denom,
-          amount: maxTokens,
+          denom: maxTokens.denom,
+          amount: maxTokens.amount,
         })
       : undefined,
     authorization_type: authorizationType,

--- a/packages/transactions/src/messages/authz/grant.ts
+++ b/packages/transactions/src/messages/authz/grant.ts
@@ -10,9 +10,11 @@ import { Chain, Fee, Sender } from '../common'
 /* eslint-disable camelcase */
 export interface MsgStakeAuthorizationParams {
   bot_address: string
-  validator_address: string
-  denom: string
-  maxTokens: string | undefined
+  validator_addresses?: string[]
+  maxTokens?: {
+    denom: string
+    amount: string
+  }
   duration_in_seconds: number
 }
 
@@ -28,8 +30,7 @@ export function createTxMsgStakeAuthorization(
 
   // Cosmos
   const msgStakeGrant = createStakeAuthorization(
-    params.validator_address,
-    params.denom,
+    params.validator_addresses,
     params.maxTokens,
     stakeAuthTypes.AUTHORIZATION_TYPE_DELEGATE,
   )


### PR DESCRIPTION
This is an attempt to make the typing more clear and accurate for staking authorizations.

- The validator white list should allow multiple validators or none and not demand single one
- `MaxTokens` should be where the denom is specified

Ultimately i understand that this is a breaking change and it's up to you all to merge it or not. closing the pr will not upset me at all :P
Big shout out to Noi for helping me with integrating Evmos MsgGrants into my dapp ❤️ 