### PR TITLE
fix: shx and link-module-alias change reverted

### DIFF
--- a/packages/address-converter/package.json
+++ b/packages/address-converter/package.json
@@ -27,9 +27,7 @@
   },
   "dependencies": {
     "bech32": "^2.0.0",
-    "crypto-addr-codec": "^0.1.7"
-  },
-  "devDependencies": {
+    "crypto-addr-codec": "^0.1.7",
     "link-module-alias": "^1.2.0",
     "shx": "^0.3.4"
   },

--- a/packages/evmosjs/package.json
+++ b/packages/evmosjs/package.json
@@ -30,12 +30,12 @@
     "@evmos/eip712": "^0.2.9",
     "@evmos/proto": "^0.1.25",
     "@evmos/provider": "^0.2.7",
-    "@evmos/transactions": "^0.2.11"
-  },
-  "devDependencies": {
-    "@types/node": "^17.0.21",
+    "@evmos/transactions": "^0.2.11",
     "link-module-alias": "^1.2.0",
     "shx": "^0.3.4"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.21"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -30,14 +30,14 @@
   },
   "dependencies": {
     "google-protobuf": "^3.19.4",
-    "sha3": "^2.1.4"
+    "sha3": "^2.1.4",
+    "link-module-alias": "^1.2.0",
+    "shx": "^0.3.4"
   },
   "devDependencies": {
     "@types/google-protobuf": "^3.15.5",
     "@types/node": "^17.0.21",
-    "link-module-alias": "^1.2.0",
-    "protoc-gen-ts": "^0.8.2",
-    "shx": "^0.3.4"
+    "protoc-gen-ts": "^0.8.2"
   },
   "gitHead": "fc2045b9357bde146e3374429453eb5d4a48a2ca",
   "publishConfig": {

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -25,10 +25,12 @@
     "dev": "ts-node-dev -r tsconfig-paths/register src/index.ts",
     "start": "node dist/index.js"
   },
-  "devDependencies": {
-    "@types/node": "^17.0.21",
+  "dependencies": {
     "link-module-alias": "^1.2.0",
     "shx": "^0.3.4"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.21"
   },
   "gitHead": "fc2045b9357bde146e3374429453eb5d4a48a2ca",
   "publishConfig": {

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -27,7 +27,9 @@
   },
   "dependencies": {
     "@evmos/eip712": "^0.2.9",
-    "@evmos/proto": "^0.1.25"
+    "@evmos/proto": "^0.1.25",
+    "link-module-alias": "^1.2.0",
+    "shx": "^0.3.4"
   },
   "devDependencies": {
     "@babel/core": "^7.18.2",
@@ -37,9 +39,7 @@
     "@types/node": "^17.0.21",
     "ethers": "^5.6.8",
     "ethers-eip712": "^0.2.0",
-    "keccak": "^3.0.2",
-    "link-module-alias": "^1.2.0",
-    "shx": "^0.3.4"
+    "keccak": "^3.0.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Revert the change to move the dependencies to only `dev` because it made the `postinstall` script fail in the case that it was needed