### PR TITLE
fix (docs): remove outdated lgtm banners from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # evmosjs
 
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/tharsis/evmosjs.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tharsis/evmosjs/alerts/) [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/tharsis/evmosjs.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tharsis/evmosjs/context:javascript)
-
 JS and TS libs for Evmos
 
 ## Example


### PR DESCRIPTION
This PR will remove the outdated LGTM banners from the README.

More infos at https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/