### PR TITLE
fix: proto refactor fixes

### DIFF
--- a/packages/proto/src/messages/common.ts
+++ b/packages/proto/src/messages/common.ts
@@ -1,4 +1,4 @@
-import { Any, Message, AnyMessage } from '@bufbuild/protobuf/'
+import { Any, Message, AnyMessage } from '@bufbuild/protobuf'
 
 export interface MessageGenerated<T extends Message<T> = AnyMessage> {
   message: Message<T>

--- a/packages/proto/src/messages/evm/msgEthereumTx.spec.ts
+++ b/packages/proto/src/messages/evm/msgEthereumTx.spec.ts
@@ -1,4 +1,4 @@
-import { Any } from '@bufbuild/protobuf/'
+import { Any } from '@bufbuild/protobuf'
 import { bytesToLegacyTx, bytesToMsgEthereumTx } from './msgEthereumTx'
 import {
   bytesToAuthInfo,

--- a/packages/proto/src/transaction/transaction.ts
+++ b/packages/proto/src/transaction/transaction.ts
@@ -1,5 +1,5 @@
 import { Keccak } from 'sha3'
-import { Any } from '@bufbuild/protobuf/'
+import { Any } from '@bufbuild/protobuf'
 import { Coin } from '../proto/cosmos/base/coin'
 import {
   TxBody,

--- a/packages/provider/src/rest/broadcast.ts
+++ b/packages/provider/src/rest/broadcast.ts
@@ -7,7 +7,7 @@ export function generateEndpointBroadcast() {
 // the complete package to just type the functions
 export interface TxToSend {
   message: {
-    serializeBinary: () => Uint8Array
+    toBinary: () => Uint8Array
   }
   path: string
 }
@@ -24,7 +24,7 @@ export function generatePostBodyBroadcast(
   broadcastMode: string = BroadcastMode.Sync,
 ) {
   return `{ "tx_bytes": [${txRaw.message
-    .serializeBinary()
+    .toBinary()
     .toString()}], "mode": "${broadcastMode}" }`
 }
 


### PR DESCRIPTION
Clone the repo:

```sh
cd /tmp
git clone git@github.com:evmos/evmosjs
cd evmosjs
git checkout austinchandra/refactor-protobuf
npm config set @buf:registry https://buf.build/gen/npm/v1
npm install
npm run build
cd packages/evmosjs
npm link
```

Create a react project
```sh
cd /tmp
npx create-next-app@latest test --typescript
```

Add the lib and use the local build
```sh
# Add the evmosjs
cd test
npm add evmosjs
npm link evmosjs
```

Call any transaction that uses proto
```ts
# Add to the file: src/pages/index.ts
import { transactions } from "evmosjs";
console.log(transactions.createMessageSend);
```

```sh
npm run dev
```

It is always erroring with the message:
```
error - ../evmosjs/packages/proto/dist/messages/common.js:1:0
Module not found: Resolving to directories is not possible with the exports field (request was ./)
> 1 | import { Any } from '@bufbuild/protobuf/';
  2 | export function createAnyMessage(msg) {
  3 |     return new Any({
  4 |         typeUrl: `/${msg.path}`,

Import trace for requested module:
../evmosjs/packages/proto/dist/messages/index.js
../evmosjs/packages/proto/dist/index.js
../evmosjs/packages/evmosjs/dist/index.js
./src/pages/index.tsx
```
