### PR TITLE
Update Package Versions for Release

### DIFF
--- a/packages/eip712/package.json
+++ b/packages/eip712/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evmos/eip712",
   "description": "EIP712 transaction creator for EVMOS.",
-  "version": "0.2.10",
+  "version": "0.3.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evmos/transactions",
   "description": "Transactions generator for EVMOS",
-  "version": "0.2.12",
+  "version": "0.3.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,7 +27,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@evmos/eip712": "^0.2.10",
+    "@evmos/eip712": "^0.3.0",
     "@evmos/proto": "^0.2.0",
     "link-module-alias": "^1.2.0",
     "shx": "^0.3.4"


### PR DESCRIPTION
Update package versions to indicate a new breaking release.

@evmos/proto has already been updated to 0.2.0.
