### PR TITLE
Add e2e test for convert coin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         run: >-
           cd packages/evmosjs/src/tests &&
           docker build -t evmosjs-test . &&
-          docker create -p 1317:1317 --name evmos -t evmosjs-test &&
+          docker create -p 1317:1317 -p 8545:8545 --name evmos -t evmosjs-test &&
           docker start evmos &&
           cd ../../../..
         if: env.GIT_DIFF

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,15 +13,15 @@
         "@commitlint/config-conventional": "^16.2.1",
         "@types/jest": "^27.0.1",
         "@types/node": "^17.0.21",
-        "@typescript-eslint/eslint-plugin": "^4.31.1",
-        "@typescript-eslint/parser": "^4.31.1",
+        "@typescript-eslint/eslint-plugin": "^4.33.0",
+        "@typescript-eslint/parser": "^4.33.0",
         "cross-env": "^7.0.3",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-config-prettier": "^8.3.0",
         "eslint-import-resolver-typescript": "^2.5.0",
-        "eslint-plugin-import": "^2.24.2",
+        "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jest": "^24.4.2",
         "eslint-plugin-markdown": "^2.2.1",
         "eslint-plugin-prettier": "^4.0.0",
@@ -38,7 +38,7 @@
         "ts-jest": "^29.0.5",
         "ts-node-dev": "^1.1.8",
         "tsconfig-paths": "^3.11.0",
-        "typescript": "^4.7.3"
+        "typescript": "^4.9.5"
       },
       "workspaces": {
         "packages": [
@@ -6337,15 +6337,14 @@
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
@@ -6360,7 +6359,6 @@
       "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
       "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -8586,14 +8584,14 @@
       }
     },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
+      "integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
-        "resolve": "^1.20.0"
+        "is-core-module": "^2.11.0",
+        "resolve": "^1.22.1"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -8601,7 +8599,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -8656,24 +8653,25 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
-      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
+      "version": "2.27.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
+      "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "array.prototype.flatmap": "^1.3.1",
+        "debug": "^3.2.7",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.3",
+        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-module-utils": "^2.7.4",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.11.0",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.values": "^1.1.5",
-        "resolve": "^1.22.0",
+        "object.values": "^1.1.6",
+        "resolve": "^1.22.1",
+        "semver": "^6.3.0",
         "tsconfig-paths": "^3.14.1"
       },
       "engines": {
@@ -8684,21 +8682,22 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
-      "license": "MIT"
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/eslint-plugin-jest": {
       "version": "24.7.0",
@@ -10833,10 +10832,9 @@
       "dev": true
     },
     "node_modules/is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
-      "license": "MIT",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -17204,11 +17202,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18035,6 +18032,7 @@
         "shx": "^0.3.4"
       },
       "devDependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
         "@ethersproject/wallet": "^5.7.0",
         "@types/node": "^17.0.21",
@@ -23005,14 +23003,14 @@
       "dev": true
     },
     "array.prototype.flat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
       }
     },
@@ -23021,7 +23019,6 @@
       "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
       "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -24725,13 +24722,14 @@
       "requires": {}
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
+      "integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
       "dev": true,
       "requires": {
         "debug": "^3.2.7",
-        "resolve": "^1.20.0"
+        "is-core-module": "^2.11.0",
+        "resolve": "^1.22.1"
       },
       "dependencies": {
         "debug": {
@@ -24779,39 +24777,41 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
-      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
+      "version": "2.27.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
+      "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "array.prototype.flatmap": "^1.3.1",
+        "debug": "^3.2.7",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.3",
+        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-module-utils": "^2.7.4",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.11.0",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.values": "^1.1.5",
-        "resolve": "^1.22.0",
+        "object.values": "^1.1.6",
+        "resolve": "^1.22.1",
+        "semver": "^6.3.0",
         "tsconfig-paths": "^3.14.1"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -25165,6 +25165,7 @@
     "evmosjs": {
       "version": "file:packages/evmosjs",
       "requires": {
+        "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
         "@ethersproject/wallet": "^5.7.0",
         "@evmos/address-converter": "^0.1.9",
@@ -26347,9 +26348,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -31014,9 +31015,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "uc.micro": {

--- a/packages/evmosjs/package-lock.json
+++ b/packages/evmosjs/package-lock.json
@@ -20,7 +20,9 @@
       },
       "devDependencies": {
         "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/contracts": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/providers": "^5.7.2",
         "@ethersproject/wallet": "^5.7.0",
         "@types/node": "^17.0.21",
         "node-fetch": "^3.3.0",
@@ -4887,6 +4889,33 @@
     "dist": {
       "extraneous": true
     },
+    "node_modules/@ethersproject/abi": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
+      }
+    },
     "node_modules/@ethersproject/abstract-provider": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
@@ -5054,6 +5083,34 @@
       ],
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/contracts": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hash": {
@@ -5236,6 +5293,44 @@
       ],
       "dependencies": {
         "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/providers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+      "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
       }
     },
     "node_modules/@ethersproject/random": {
@@ -6606,9 +6701,47 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   },
   "dependencies": {
+    "@ethersproject/abi": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
+      }
+    },
     "@ethersproject/abstract-provider": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
@@ -6696,6 +6829,24 @@
       "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.7.0"
+      }
+    },
+    "@ethersproject/contracts": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
       }
     },
     "@ethersproject/hash": {
@@ -6798,6 +6949,34 @@
       "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "@ethersproject/providers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+      "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
       }
     },
     "@ethersproject/random": {
@@ -10938,6 +11117,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true,
+      "requires": {}
     }
   }
 }

--- a/packages/evmosjs/package-lock.json
+++ b/packages/evmosjs/package-lock.json
@@ -19,6 +19,7 @@
         "shx": "^0.3.4"
       },
       "devDependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
         "@ethersproject/wallet": "^5.7.0",
         "@types/node": "^17.0.21",

--- a/packages/evmosjs/package.json
+++ b/packages/evmosjs/package.json
@@ -36,6 +36,7 @@
     "shx": "^0.3.4"
   },
   "devDependencies": {
+    "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/keccak256": "^5.7.0",
     "@ethersproject/wallet": "^5.7.0",
     "@types/node": "^17.0.21",

--- a/packages/evmosjs/package.json
+++ b/packages/evmosjs/package.json
@@ -37,7 +37,9 @@
   },
   "devDependencies": {
     "@ethersproject/bignumber": "^5.7.0",
+    "@ethersproject/contracts": "^5.7.0",
     "@ethersproject/keccak256": "^5.7.0",
+    "@ethersproject/providers": "^5.7.2",
     "@ethersproject/wallet": "^5.7.0",
     "@types/node": "^17.0.21",
     "node-fetch": "^3.3.0",

--- a/packages/evmosjs/src/tests/Dockerfile
+++ b/packages/evmosjs/src/tests/Dockerfile
@@ -26,6 +26,6 @@ RUN chmod +x init-node.sh
 
 COPY --from=build-env /go/src/github.com/evmos/evmos/build/evmosd /usr/bin/evmosd
 
-EXPOSE 1317 8545
+EXPOSE 1317 8545 26657
 
 CMD ["sh", "./init-node.sh"]

--- a/packages/evmosjs/src/tests/init-node.sh
+++ b/packages/evmosjs/src/tests/init-node.sh
@@ -43,8 +43,8 @@ jq '.app_state.evm.params.evm_denom="aevmos"' "$GENESIS" > "$TMP_GENESIS" && mv 
 jq '.app_state.inflation.params.mint_denom="aevmos"' "$GENESIS" > "$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 
 # set gov proposing && voting period
-jq '.app_state.gov.deposit_params.max_deposit_period="15s"' "$GENESIS" > "$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
-jq '.app_state.gov.voting_params.voting_period="15s"' "$GENESIS" > "$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+jq '.app_state.gov.deposit_params.max_deposit_period="10s"' "$GENESIS" > "$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+jq '.app_state.gov.voting_params.voting_period="10s"' "$GENESIS" > "$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 
 # Set gas limit in genesis
 jq '.consensus_params.block.max_gas="10000000"' "$GENESIS" > "$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"

--- a/packages/evmosjs/src/tests/network.spec.ts
+++ b/packages/evmosjs/src/tests/network.spec.ts
@@ -3,20 +3,18 @@ import { expectSuccess } from './network/common'
 import { MsgSendUtils } from './utils'
 import ConvertCoinClient from './network/integration/convertCoin/main'
 
+const networkClient = new NetworkClient()
+
 describe('evmosjs e2e integration tests', () => {
   it('fulfills msgsend transactions', async () => {
-    const client = new NetworkClient()
-    const response = await client.signDirectAndBroadcast(
+    const response = await networkClient.signDirectAndBroadcast(
       MsgSendUtils.generateTx,
     )
-
     expectSuccess(response)
-
-    await new Promise((resolve) => setTimeout(resolve, 5000))
-  }, 10000)
+  })
 
   it('fulfills msgconverterc20 transactions', async () => {
-    const client = new ConvertCoinClient()
+    const client = new ConvertCoinClient(networkClient)
     await client.testIntegration()
-  }, 50000)
+  }, 30000)
 })

--- a/packages/evmosjs/src/tests/network.spec.ts
+++ b/packages/evmosjs/src/tests/network.spec.ts
@@ -1,19 +1,14 @@
-import NetworkClient, { TxResponse } from './network/client'
+import NetworkClient from './network/client'
+import { expectSuccess } from './network/common'
 import { MsgSendUtils } from './utils'
-import SubmitProposalIntegration from './network/integration/convertCoin/submitProposal'
-import DelegateIntegration from './network/integration/convertCoin/delegate'
-import VoteIntegration from './network/integration/convertCoin/vote'
-import ConvertCoinIntegration from './network/integration/convertCoin/convertCoin'
-
-const expectSuccess = (response: TxResponse) => {
-  // eslint-disable-next-line camelcase
-  expect(response.tx_response.code).toBe(0)
-}
+import ConvertCoinClient from './network/integration/convertCoin/main'
 
 describe('evmosjs e2e integration tests', () => {
   it('fulfills msgsend transactions', async () => {
-    const client = new NetworkClient(MsgSendUtils.generateTx)
-    const response = await client.signDirectAndBroadcast()
+    const client = new NetworkClient()
+    const response = await client.signDirectAndBroadcast(
+      MsgSendUtils.generateTx,
+    )
 
     expectSuccess(response)
 
@@ -21,51 +16,7 @@ describe('evmosjs e2e integration tests', () => {
   }, 10000)
 
   it('fulfills msgconverterc20 transactions', async () => {
-    const submitConvertCoinProposal = async () => {
-      const integrationClient = new SubmitProposalIntegration()
-
-      const response = await integrationClient.sendTx()
-
-      expectSuccess(response)
-
-      await new Promise((resolve) => setTimeout(resolve, 5000))
-      await integrationClient.verifyStateChange()
-    }
-
-    const bondTokens = async () => {
-      const integrationClient = new DelegateIntegration()
-
-      const response = await integrationClient.sendTx()
-
-      expectSuccess(response)
-
-      await new Promise((resolve) => setTimeout(resolve, 5000))
-      await integrationClient.verifyStateChange()
-    }
-
-    const voteOnProposal = async () => {
-      const integrationClient = new VoteIntegration()
-      const response = await integrationClient.sendTx()
-
-      expectSuccess(response)
-
-      await new Promise((resolve) => setTimeout(resolve, 20000))
-      await integrationClient.verifyStateChange()
-    }
-
-    const convertCoin = async () => {
-      const integrationClient = new ConvertCoinIntegration()
-      const response = await integrationClient.sendTx()
-
-      expectSuccess(response)
-
-      await new Promise((resolve) => setTimeout(resolve, 5000))
-      await integrationClient.verifyStateChange()
-    }
-
-    await submitConvertCoinProposal()
-    await bondTokens()
-    await voteOnProposal()
-    await convertCoin()
+    const client = new ConvertCoinClient()
+    await client.testIntegration()
   }, 50000)
 })

--- a/packages/evmosjs/src/tests/network.spec.ts
+++ b/packages/evmosjs/src/tests/network.spec.ts
@@ -1,5 +1,9 @@
 import NetworkClient, { TxResponse } from './network/client'
 import { MsgSendUtils } from './utils'
+import SubmitProposalIntegration from './network/integration/convertCoin/submitProposal'
+import DelegateIntegration from './network/integration/convertCoin/delegate'
+import VoteIntegration from './network/integration/convertCoin/vote'
+import ConvertCoinIntegration from './network/integration/convertCoin/convertCoin'
 
 const expectSuccess = (response: TxResponse) => {
   // eslint-disable-next-line camelcase
@@ -12,5 +16,56 @@ describe('evmosjs e2e integration tests', () => {
     const response = await client.signDirectAndBroadcast()
 
     expectSuccess(response)
-  })
+
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+  }, 10000)
+
+  it('fulfills msgconverterc20 transactions', async () => {
+    const submitConvertCoinProposal = async () => {
+      const integrationClient = new SubmitProposalIntegration()
+
+      const response = await integrationClient.sendTx()
+
+      expectSuccess(response)
+
+      await new Promise((resolve) => setTimeout(resolve, 5000))
+      await integrationClient.verifyStateChange()
+    }
+
+    const bondTokens = async () => {
+      const integrationClient = new DelegateIntegration()
+
+      const response = await integrationClient.sendTx()
+
+      expectSuccess(response)
+
+      await new Promise((resolve) => setTimeout(resolve, 5000))
+      await integrationClient.verifyStateChange()
+    }
+
+    const voteOnProposal = async () => {
+      const integrationClient = new VoteIntegration()
+      const response = await integrationClient.sendTx()
+
+      expectSuccess(response)
+
+      await new Promise((resolve) => setTimeout(resolve, 20000))
+      await integrationClient.verifyStateChange()
+    }
+
+    const convertCoin = async () => {
+      const integrationClient = new ConvertCoinIntegration()
+      const response = await integrationClient.sendTx()
+
+      expectSuccess(response)
+
+      await new Promise((resolve) => setTimeout(resolve, 5000))
+      await integrationClient.verifyStateChange()
+    }
+
+    await submitConvertCoinProposal()
+    await bondTokens()
+    await voteOnProposal()
+    await convertCoin()
+  }, 50000)
 })

--- a/packages/evmosjs/src/tests/network/client.ts
+++ b/packages/evmosjs/src/tests/network/client.ts
@@ -28,7 +28,7 @@ class NetworkTestClient {
 
     console.log(response)
 
-    if (this.nonce) {
+    if (this.nonce !== undefined) {
       this.nonce += 1
     }
 

--- a/packages/evmosjs/src/tests/network/client.ts
+++ b/packages/evmosjs/src/tests/network/client.ts
@@ -10,6 +10,7 @@ export interface TxResponse {
   // eslint-disable-next-line camelcase
   tx_response: {
     code: number
+    txhash: string
   }
 }
 
@@ -29,9 +30,11 @@ class NetworkTestClient {
     const payload = this.createTxPayload(context)
 
     const signedTx = await signDirect(payload)
-    const response = (await broadcastTx(signedTx)) as TxResponse
+    const response = await broadcastTx(signedTx)
 
-    return response
+    console.log(response)
+
+    return response as TxResponse
   }
 
   private createTxContext = async () => {

--- a/packages/evmosjs/src/tests/network/common.ts
+++ b/packages/evmosjs/src/tests/network/common.ts
@@ -1,0 +1,6 @@
+import { TxResponse } from './client'
+
+export const expectSuccess = (response: TxResponse) => {
+  // eslint-disable-next-line camelcase
+  expect(response.tx_response.code).toBe(0)
+}

--- a/packages/evmosjs/src/tests/network/common.ts
+++ b/packages/evmosjs/src/tests/network/common.ts
@@ -4,3 +4,6 @@ export const expectSuccess = (response: TxResponse) => {
   // eslint-disable-next-line camelcase
   expect(response.tx_response.code).toBe(0)
 }
+
+export const delay = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms))

--- a/packages/evmosjs/src/tests/network/integration/convertCoin/convertCoin.ts
+++ b/packages/evmosjs/src/tests/network/integration/convertCoin/convertCoin.ts
@@ -1,9 +1,11 @@
 import { TxContext, createTxMsgConvertCoin } from '@evmos/transactions'
 import { BalanceByDenomResponse, Coin } from '@evmos/provider'
 import { BigNumber } from '@ethersproject/bignumber'
+import { JsonRpcProvider } from '@ethersproject/providers'
+import { Contract } from '@ethersproject/contracts'
 import IntegrationClientBase from '../types'
-import { ibcDenom, senderAddress, senderHex } from '../../params'
-import { fetchBalanceByDenom } from '../../query'
+import { ibcDenom, senderAddress, senderHex, jsonRPCUrl } from '../../params'
+import { fetchBalanceByDenom, fetchERC20ContractAddress } from '../../query'
 
 class ConvertCoinConvertCoinClient extends IntegrationClientBase {
   private previousBalanceResponse: BalanceByDenomResponse | undefined
@@ -39,6 +41,11 @@ class ConvertCoinConvertCoinClient extends IntegrationClientBase {
   }
 
   verifyStateChange = async () => {
+    await this.verifyIBCBalanceStateChange()
+    await this.verifyERC20StateChange()
+  }
+
+  private verifyIBCBalanceStateChange = async () => {
     const { previousBalanceResponse } = this
     if (!previousBalanceResponse) {
       throw new Error(
@@ -47,13 +54,13 @@ class ConvertCoinConvertCoinClient extends IntegrationClientBase {
     }
 
     const balanceResponse = await fetchBalanceByDenom(senderAddress, ibcDenom)
-    this.verifyBalanceDecreased(
+    this.verifyIBCBalanceDecreased(
       previousBalanceResponse.balance,
       balanceResponse.balance,
     )
   }
 
-  private verifyBalanceDecreased = (previous: Coin, current: Coin) => {
+  private verifyIBCBalanceDecreased = (previous: Coin, current: Coin) => {
     const previousBalance = BigNumber.from(previous.amount)
     const currentBalance = BigNumber.from(current.amount)
     const diff = BigNumber.from(this.transferAmount)
@@ -61,6 +68,33 @@ class ConvertCoinConvertCoinClient extends IntegrationClientBase {
     expect(currentBalance.toString()).toStrictEqual(
       previousBalance.sub(diff).toString(),
     )
+  }
+
+  private verifyERC20StateChange = async () => {
+    const contractAddress = await this.fetchContractAddress()
+    const balance = await this.fetchContractBalance(contractAddress)
+
+    const expBalance = BigNumber.from(this.transferAmount)
+
+    expect(balance.toString()).toBe(expBalance.toString())
+  }
+
+  private fetchContractAddress = async () => {
+    const response = await fetchERC20ContractAddress()
+    const tokenPairs = response.token_pairs
+    const latestPair = tokenPairs[tokenPairs.length - 1]
+
+    return latestPair.erc20_address
+  }
+
+  private fetchContractBalance = async (address: string) => {
+    const provider = new JsonRpcProvider(jsonRPCUrl)
+    const abi = ['function balanceOf(address owner) view returns (uint256)']
+
+    const contract = new Contract(address, abi, provider)
+    const balance = await contract.balanceOf(senderHex)
+
+    return balance
   }
 }
 

--- a/packages/evmosjs/src/tests/network/integration/convertCoin/convertCoin.ts
+++ b/packages/evmosjs/src/tests/network/integration/convertCoin/convertCoin.ts
@@ -1,11 +1,11 @@
 import { TxContext, createTxMsgConvertCoin } from '@evmos/transactions'
 import { BalanceByDenomResponse, Coin } from '@evmos/provider'
 import { BigNumber } from '@ethersproject/bignumber'
-import NetworkClient from '../../client'
+import IntegrationClientBase from '../types'
 import { ibcDenom, senderAddress, senderHex } from '../../params'
 import { fetchBalanceByDenom } from '../../query'
 
-class ConvertCoinConvertCoinClient {
+class ConvertCoinConvertCoinClient extends IntegrationClientBase {
   private previousBalanceResponse: BalanceByDenomResponse | undefined
 
   private transferAmount: string = '1000'
@@ -16,11 +16,10 @@ class ConvertCoinConvertCoinClient {
       ibcDenom,
     )
 
-    const client = new NetworkClient(this.generator)
-    return client.signDirectAndBroadcast()
+    return this.networkClient.signDirectAndBroadcast(this.createPayload)
   }
 
-  private generator = (context: TxContext) => {
+  private createPayload = (context: TxContext) => {
     const params = this.getParams()
     return createTxMsgConvertCoin(context, params)
   }

--- a/packages/evmosjs/src/tests/network/integration/convertCoin/convertCoin.ts
+++ b/packages/evmosjs/src/tests/network/integration/convertCoin/convertCoin.ts
@@ -1,0 +1,68 @@
+import { TxContext, createTxMsgConvertCoin } from '@evmos/transactions'
+import { BalanceByDenomResponse, Coin } from '@evmos/provider'
+import { BigNumber } from '@ethersproject/bignumber'
+import NetworkClient from '../../client'
+import { ibcDenom, senderAddress, senderHex } from '../../params'
+import { fetchBalanceByDenom } from '../../query'
+
+class ConvertCoinConvertCoinClient {
+  private previousBalanceResponse: BalanceByDenomResponse | undefined
+
+  private transferAmount: string = '1000'
+
+  sendTx = async () => {
+    this.previousBalanceResponse = await fetchBalanceByDenom(
+      senderAddress,
+      ibcDenom,
+    )
+
+    const client = new NetworkClient(this.generator)
+    return client.signDirectAndBroadcast()
+  }
+
+  private generator = (context: TxContext) => {
+    const params = this.getParams()
+    return createTxMsgConvertCoin(context, params)
+  }
+
+  private getParams = () => {
+    const amount = this.transferAmount
+    const denom = ibcDenom
+    const receiverHex = senderHex
+    const senderBech32 = senderAddress
+
+    return {
+      denom,
+      amount,
+      receiverHex,
+      senderBech32,
+    }
+  }
+
+  verifyStateChange = async () => {
+    const { previousBalanceResponse } = this
+    if (!previousBalanceResponse) {
+      throw new Error(
+        'must fetch previous ibc balance before checking state change',
+      )
+    }
+
+    const balanceResponse = await fetchBalanceByDenom(senderAddress, ibcDenom)
+    this.verifyBalanceDecreased(
+      previousBalanceResponse.balance,
+      balanceResponse.balance,
+    )
+  }
+
+  private verifyBalanceDecreased = (previous: Coin, current: Coin) => {
+    const previousBalance = BigNumber.from(previous.amount)
+    const currentBalance = BigNumber.from(current.amount)
+    const diff = BigNumber.from(this.transferAmount)
+
+    expect(currentBalance.toString()).toStrictEqual(
+      previousBalance.sub(diff).toString(),
+    )
+  }
+}
+
+export default ConvertCoinConvertCoinClient

--- a/packages/evmosjs/src/tests/network/integration/convertCoin/delegate.ts
+++ b/packages/evmosjs/src/tests/network/integration/convertCoin/delegate.ts
@@ -1,0 +1,59 @@
+import { TxContext, createTxMsgDelegate } from '@evmos/transactions'
+import { GetValidatorsResponse } from '@evmos/provider'
+import { BigNumber } from '@ethersproject/bignumber'
+import NetworkClient from '../../client'
+import { denom } from '../../params'
+import { fetchValidators } from '../../query'
+
+class ConvertCoinDelegateClient {
+  private previousValidators: GetValidatorsResponse | undefined
+
+  private stakeAmount = '500000000000000000000000000'
+
+  sendTx = async () => {
+    this.previousValidators = await fetchValidators()
+
+    const client = new NetworkClient(this.generator)
+    return client.signDirectAndBroadcast()
+  }
+
+  private generator = (context: TxContext) => {
+    const validatorAddress = this.getValidatorAddress()
+    const params = this.getParams(validatorAddress)
+
+    return createTxMsgDelegate(context, params)
+  }
+
+  private getValidatorAddress = () => {
+    const { previousValidators } = this
+    if (!previousValidators) {
+      throw new Error('must fetch validators before getting validator address')
+    }
+
+    return previousValidators.validators[0].operator_address
+  }
+
+  private getParams = (validatorAddress: string) => {
+    const amount = this.stakeAmount
+
+    return {
+      validatorAddress,
+      amount,
+      denom,
+    }
+  }
+
+  verifyStateChange = async () => {
+    const response = await fetchValidators()
+    expect(this.stateIncludesDelegation(response)).toBe(true)
+  }
+
+  private stateIncludesDelegation = (response: GetValidatorsResponse) => {
+    const delegation = BigNumber.from(response.validators[0].tokens)
+    const target = BigNumber.from(this.stakeAmount)
+
+    return delegation.gte(target)
+  }
+}
+
+export default ConvertCoinDelegateClient

--- a/packages/evmosjs/src/tests/network/integration/convertCoin/delegate.ts
+++ b/packages/evmosjs/src/tests/network/integration/convertCoin/delegate.ts
@@ -1,11 +1,11 @@
 import { TxContext, createTxMsgDelegate } from '@evmos/transactions'
 import { GetValidatorsResponse } from '@evmos/provider'
 import { BigNumber } from '@ethersproject/bignumber'
-import NetworkClient from '../../client'
+import IntegrationClientBase from '../types'
 import { denom } from '../../params'
 import { fetchValidators } from '../../query'
 
-class ConvertCoinDelegateClient {
+class ConvertCoinDelegateClient extends IntegrationClientBase {
   private previousValidators: GetValidatorsResponse | undefined
 
   private stakeAmount = '500000000000000000000000000'
@@ -13,11 +13,10 @@ class ConvertCoinDelegateClient {
   sendTx = async () => {
     this.previousValidators = await fetchValidators()
 
-    const client = new NetworkClient(this.generator)
-    return client.signDirectAndBroadcast()
+    return this.networkClient.signDirectAndBroadcast(this.createPayload)
   }
 
-  private generator = (context: TxContext) => {
+  private createPayload = (context: TxContext) => {
     const validatorAddress = this.getValidatorAddress()
     const params = this.getParams(validatorAddress)
 

--- a/packages/evmosjs/src/tests/network/integration/convertCoin/main.ts
+++ b/packages/evmosjs/src/tests/network/integration/convertCoin/main.ts
@@ -1,0 +1,65 @@
+import { expectSuccess } from '../../common'
+import NetworkClient from '../../client'
+import SubmitProposalClient from './submitProposal'
+import DelegateClient from './delegate'
+import VoteClient from './vote'
+import ConvertCoinClient from './convertCoin'
+
+class ConvertCoinIntegrationClient {
+  public networkClient: NetworkClient
+
+  constructor() {
+    this.networkClient = new NetworkClient()
+  }
+
+  testIntegration = async () => {
+    await this.submitConvertCoinProposal()
+    await this.bondTokens()
+    await this.voteOnProposal()
+    await this.convertCoin()
+  }
+
+  private submitConvertCoinProposal = async () => {
+    const integrationClient = new SubmitProposalClient(this.networkClient)
+
+    const response = await integrationClient.sendTx()
+
+    expectSuccess(response)
+
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+    await integrationClient.verifyStateChange()
+  }
+
+  private bondTokens = async () => {
+    const integrationClient = new DelegateClient(this.networkClient)
+
+    const response = await integrationClient.sendTx()
+
+    expectSuccess(response)
+
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+    await integrationClient.verifyStateChange()
+  }
+
+  private voteOnProposal = async () => {
+    const integrationClient = new VoteClient(this.networkClient)
+    const response = await integrationClient.sendTx()
+
+    expectSuccess(response)
+
+    await new Promise((resolve) => setTimeout(resolve, 20000))
+    await integrationClient.verifyStateChange()
+  }
+
+  private convertCoin = async () => {
+    const integrationClient = new ConvertCoinClient(this.networkClient)
+    const response = await integrationClient.sendTx()
+
+    expectSuccess(response)
+
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+    await integrationClient.verifyStateChange()
+  }
+}
+
+export default ConvertCoinIntegrationClient

--- a/packages/evmosjs/src/tests/network/integration/convertCoin/submitProposal.ts
+++ b/packages/evmosjs/src/tests/network/integration/convertCoin/submitProposal.ts
@@ -62,17 +62,28 @@ class ConvertCoinSubmitProposalClient extends IntegrationClientBase {
     }
   }
 
+  getProposalId = () => {
+    const previousProposals = this.getPreviousProposals()
+    return previousProposals.proposals.length + 1
+  }
+
   verifyStateChange = async () => {
     const proposals = await fetchProposals()
+    const previousProposals = this.getPreviousProposals()
+
+    expect(proposals.proposals).toHaveLength(
+      previousProposals.proposals.length + 1,
+    )
+  }
+
+  private getPreviousProposals = () => {
     const { previousProposals } = this
 
     if (!previousProposals) {
       throw new Error('must fetch previous proposals before verifying state')
     }
 
-    expect(proposals.proposals).toHaveLength(
-      previousProposals.proposals.length + 1,
-    )
+    return previousProposals
   }
 }
 

--- a/packages/evmosjs/src/tests/network/integration/convertCoin/submitProposal.ts
+++ b/packages/evmosjs/src/tests/network/integration/convertCoin/submitProposal.ts
@@ -1,0 +1,80 @@
+import { TxContext, createTxMsgSubmitProposal } from '@evmos/transactions'
+import { createMsgRegisterCoin, Proto } from '@evmos/proto'
+import { ProposalsResponse } from '@evmos/provider'
+import NetworkClient from '../../client'
+import { ibcDenom, denom } from '../../params'
+import { fetchProposals } from '../../query'
+
+class ConvertCoinSubmitProposalClient {
+  private previousProposals: ProposalsResponse | undefined
+
+  sendTx = async () => {
+    this.previousProposals = await fetchProposals()
+
+    const client = new NetworkClient(this.generator)
+    return client.signDirectAndBroadcast()
+  }
+
+  private generator = (context: TxContext) => {
+    const params = this.getParams(context)
+    return createTxMsgSubmitProposal(context, params)
+  }
+
+  private getParams = (context: TxContext) => {
+    const token = 'token'
+    const title = 'Test Token'
+    // TODO: Find out why this must be 'Test token' and breaks on other values
+    const tokenDescription = 'Test token'
+
+    const ibcUnit = new Proto.Cosmos.Bank.Bank.DenomUnit({
+      denom: ibcDenom,
+      exponent: 0,
+      aliases: ['ibctoken'],
+    })
+
+    const baseUnit = new Proto.Cosmos.Bank.Bank.DenomUnit({
+      denom: token,
+      exponent: 6,
+    })
+
+    const metadata = new Proto.Cosmos.Bank.Bank.Metadata({
+      description: tokenDescription,
+      denomUnits: [ibcUnit, baseUnit],
+      base: ibcDenom,
+      display: token,
+      name: title,
+      symbol: token,
+    })
+
+    const content = createMsgRegisterCoin(
+      'Register Test - Convert Coin',
+      'Description',
+      [metadata],
+    )
+
+    const deposit = '100000000000'
+    const proposer = context.sender.accountAddress
+
+    return {
+      content,
+      denom,
+      amount: deposit,
+      proposer,
+    }
+  }
+
+  verifyStateChange = async () => {
+    const proposals = await fetchProposals()
+    const { previousProposals } = this
+
+    if (!previousProposals) {
+      throw new Error('must fetch previous proposals before verifying state')
+    }
+
+    expect(proposals.proposals).toHaveLength(
+      previousProposals.proposals.length + 1,
+    )
+  }
+}
+
+export default ConvertCoinSubmitProposalClient

--- a/packages/evmosjs/src/tests/network/integration/convertCoin/submitProposal.ts
+++ b/packages/evmosjs/src/tests/network/integration/convertCoin/submitProposal.ts
@@ -1,21 +1,20 @@
 import { TxContext, createTxMsgSubmitProposal } from '@evmos/transactions'
 import { createMsgRegisterCoin, Proto } from '@evmos/proto'
 import { ProposalsResponse } from '@evmos/provider'
-import NetworkClient from '../../client'
+import IntegrationClientBase from '../types'
 import { ibcDenom, denom } from '../../params'
 import { fetchProposals } from '../../query'
 
-class ConvertCoinSubmitProposalClient {
+class ConvertCoinSubmitProposalClient extends IntegrationClientBase {
   private previousProposals: ProposalsResponse | undefined
 
   sendTx = async () => {
     this.previousProposals = await fetchProposals()
 
-    const client = new NetworkClient(this.generator)
-    return client.signDirectAndBroadcast()
+    return this.networkClient.signDirectAndBroadcast(this.createPayload)
   }
 
-  private generator = (context: TxContext) => {
+  private createPayload = (context: TxContext) => {
     const params = this.getParams(context)
     return createTxMsgSubmitProposal(context, params)
   }

--- a/packages/evmosjs/src/tests/network/integration/convertCoin/vote.ts
+++ b/packages/evmosjs/src/tests/network/integration/convertCoin/vote.ts
@@ -1,20 +1,19 @@
 import { TxContext, createTxMsgVote } from '@evmos/transactions'
 import { Proposal } from '@evmos/provider'
-import NetworkClient from '../../client'
+import IntegrationClientBase from '../types'
 import { fetchProposals } from '../../query'
 
-class ConvertCoinVoteClient {
+class ConvertCoinVoteClient extends IntegrationClientBase {
   private proposalId: number | undefined
 
   sendTx = async () => {
     const query = await fetchProposals()
     this.proposalId = query.proposals.length
 
-    const client = new NetworkClient(this.generator)
-    return client.signDirectAndBroadcast()
+    return this.networkClient.signDirectAndBroadcast(this.createPayload)
   }
 
-  private generator = (context: TxContext) => {
+  private createPayload = (context: TxContext) => {
     const { proposalId } = this
     if (!proposalId) {
       throw new Error('must fetch proposal id before generating')

--- a/packages/evmosjs/src/tests/network/integration/convertCoin/vote.ts
+++ b/packages/evmosjs/src/tests/network/integration/convertCoin/vote.ts
@@ -1,0 +1,57 @@
+import { TxContext, createTxMsgVote } from '@evmos/transactions'
+import { Proposal } from '@evmos/provider'
+import NetworkClient from '../../client'
+import { fetchProposals } from '../../query'
+
+class ConvertCoinVoteClient {
+  private proposalId: number | undefined
+
+  sendTx = async () => {
+    const query = await fetchProposals()
+    this.proposalId = query.proposals.length
+
+    const client = new NetworkClient(this.generator)
+    return client.signDirectAndBroadcast()
+  }
+
+  private generator = (context: TxContext) => {
+    const { proposalId } = this
+    if (!proposalId) {
+      throw new Error('must fetch proposal id before generating')
+    }
+
+    const params = this.getParams(proposalId)
+
+    return createTxMsgVote(context, params)
+  }
+
+  private getParams = (proposalId: number) => {
+    const option = 1
+
+    return {
+      proposalId,
+      option,
+    }
+  }
+
+  verifyStateChange = async () => {
+    const response = await fetchProposals()
+    const { proposals } = response
+    const { proposalId } = this
+
+    if (!proposalId) {
+      throw new Error('must fetch proposal id before verifying state')
+    }
+
+    expect(proposals.length).toBeGreaterThanOrEqual(proposalId)
+    const proposal = proposals[proposalId - 1]
+
+    this.verifyProposalPassed(proposal)
+  }
+
+  private verifyProposalPassed = (proposal: Proposal) => {
+    expect(proposal.status).toBe('PROPOSAL_STATUS_PASSED')
+  }
+}
+
+export default ConvertCoinVoteClient

--- a/packages/evmosjs/src/tests/network/integration/convertCoin/vote.ts
+++ b/packages/evmosjs/src/tests/network/integration/convertCoin/vote.ts
@@ -7,16 +7,13 @@ class ConvertCoinVoteClient extends IntegrationClientBase {
   private proposalId: number | undefined
 
   sendTx = async () => {
-    const query = await fetchProposals()
-    this.proposalId = query.proposals.length
-
     return this.networkClient.signDirectAndBroadcast(this.createPayload)
   }
 
   private createPayload = (context: TxContext) => {
     const { proposalId } = this
     if (!proposalId) {
-      throw new Error('must fetch proposal id before generating')
+      throw new Error('must set proposal id before generating')
     }
 
     const params = this.getParams(proposalId)
@@ -33,13 +30,17 @@ class ConvertCoinVoteClient extends IntegrationClientBase {
     }
   }
 
+  setProposalId = (proposalId: number) => {
+    this.proposalId = proposalId
+  }
+
   verifyStateChange = async () => {
     const response = await fetchProposals()
     const { proposals } = response
     const { proposalId } = this
 
     if (!proposalId) {
-      throw new Error('must fetch proposal id before verifying state')
+      throw new Error('must set proposal id before verifying state')
     }
 
     expect(proposals.length).toBeGreaterThanOrEqual(proposalId)

--- a/packages/evmosjs/src/tests/network/integration/types.ts
+++ b/packages/evmosjs/src/tests/network/integration/types.ts
@@ -1,12 +1,15 @@
+/* eslint-disable max-classes-per-file */
 import NetworkClient, { TxResponse } from '../client'
 
-abstract class IntegrationClientBase {
+export abstract class NetworkClientHost {
   public networkClient: NetworkClient
 
   constructor(client: NetworkClient) {
     this.networkClient = client
   }
+}
 
+abstract class IntegrationClientBase extends NetworkClientHost {
   abstract readonly sendTx: () => Promise<TxResponse>
 
   abstract readonly verifyStateChange: () => Promise<void>

--- a/packages/evmosjs/src/tests/network/integration/types.ts
+++ b/packages/evmosjs/src/tests/network/integration/types.ts
@@ -1,0 +1,15 @@
+import NetworkClient, { TxResponse } from '../client'
+
+abstract class IntegrationClientBase {
+  public networkClient: NetworkClient
+
+  constructor(client: NetworkClient) {
+    this.networkClient = client
+  }
+
+  abstract readonly sendTx: () => Promise<TxResponse>
+
+  abstract readonly verifyStateChange: () => Promise<void>
+}
+
+export default IntegrationClientBase

--- a/packages/evmosjs/src/tests/network/params.ts
+++ b/packages/evmosjs/src/tests/network/params.ts
@@ -9,6 +9,7 @@ export const senderAddress = 'evmos16famsnv0hqks7z9h60cn052y4t46jhsk20792m'
 export const destinationAddress = 'evmos1c8y9awp83aurchlzzql3ujkqgxcfg9s2uu7a0c'
 
 export const nodeUrl = 'http://localhost:1317'
+export const jsonRPCUrl = 'http://localhost:8545'
 export const chainId = 9000
 export const cosmosChainId = 'evmos_9000-1'
 export const denom = 'aevmos'

--- a/packages/evmosjs/src/tests/network/params.ts
+++ b/packages/evmosjs/src/tests/network/params.ts
@@ -4,6 +4,7 @@ import { Fee } from '@evmos/transactions'
 const seed =
   'inmate snack that position deliver hybrid gasp open that wrestle siege goddess'
 export const wallet = Wallet.fromMnemonic(seed)
+export const senderHex = wallet.address
 export const senderAddress = 'evmos16famsnv0hqks7z9h60cn052y4t46jhsk20792m'
 export const destinationAddress = 'evmos1c8y9awp83aurchlzzql3ujkqgxcfg9s2uu7a0c'
 
@@ -12,8 +13,11 @@ export const chainId = 9000
 export const cosmosChainId = 'evmos_9000-1'
 export const denom = 'aevmos'
 
+export const ibcDenom =
+  'ibc/14F9BC3E44B8A9C1BE1FB08980FAB87034C9905EF17CF2F5008FC085218811CC'
+
 export const fee: Fee = {
-  amount: '500000000000000',
+  amount: '10000000000000000',
   denom,
-  gas: '200000',
+  gas: '10000000',
 }

--- a/packages/evmosjs/src/tests/network/query.ts
+++ b/packages/evmosjs/src/tests/network/query.ts
@@ -26,6 +26,17 @@ export interface SenderInfo {
   }
 }
 
+export interface TokenPairResponse {
+  token_pairs: [
+    {
+      erc20_address: string
+      denom: string
+      enabled: boolean
+      contract_owner: string
+    },
+  ]
+}
+
 const restOptions = {
   method: 'GET',
   headers: { 'Content-Type': 'application/json' },
@@ -68,6 +79,15 @@ export const fetchBalanceByDenom = async (address: string, denom: string) => {
   const rawResult = await fetch(queryEndpoint, restOptions)
 
   const result = (await rawResult.json()) as BalanceByDenomResponse
+
+  return result
+}
+
+export const fetchERC20ContractAddress = async () => {
+  const queryEndpoint = `${nodeUrl}/evmos/erc20/v1/token_pairs`
+  const rawResult = await fetch(queryEndpoint, restOptions)
+
+  const result = (await rawResult.json()) as TokenPairResponse
 
   return result
 }

--- a/packages/evmosjs/src/tests/network/query.ts
+++ b/packages/evmosjs/src/tests/network/query.ts
@@ -1,5 +1,13 @@
 /* eslint-disable camelcase */
-import { generateEndpointAccount } from '@evmos/provider'
+import {
+  generateEndpointAccount,
+  generateEndpointGetValidators,
+  generateEndpointProposals,
+  generateEndpointBalanceByDenom,
+  GetValidatorsResponse,
+  ProposalsResponse,
+  BalanceByDenomResponse,
+} from '@evmos/provider'
 import fetch from 'node-fetch'
 import { senderAddress, nodeUrl } from './params'
 
@@ -18,19 +26,48 @@ export interface SenderInfo {
   }
 }
 
+const restOptions = {
+  method: 'GET',
+  headers: { 'Content-Type': 'application/json' },
+}
+
 export const fetchSenderInfo = async () => {
   const address = senderAddress
 
   const queryEndpoint = `${nodeUrl}${generateEndpointAccount(address)}`
-
-  const restOptions = {
-    method: 'GET',
-    headers: { 'Content-Type': 'application/json' },
-  }
-
   const rawResult = await fetch(queryEndpoint, restOptions)
 
   const result = (await rawResult.json()) as SenderInfo | undefined
+
+  return result
+}
+
+export const fetchProposals = async () => {
+  const queryEndpoint = `${nodeUrl}${generateEndpointProposals()}`
+  const rawResult = await fetch(queryEndpoint, restOptions)
+
+  const result = (await rawResult.json()) as ProposalsResponse
+
+  return result
+}
+
+export const fetchValidators = async () => {
+  const queryEndpoint = `${nodeUrl}${generateEndpointGetValidators()}`
+  const rawResult = await fetch(queryEndpoint, restOptions)
+
+  const result = (await rawResult.json()) as GetValidatorsResponse
+
+  return result
+}
+
+export const fetchBalanceByDenom = async (address: string, denom: string) => {
+  const queryEndpoint = `${nodeUrl}${generateEndpointBalanceByDenom(
+    address,
+    denom,
+  )}`
+  const rawResult = await fetch(queryEndpoint, restOptions)
+
+  const result = (await rawResult.json()) as BalanceByDenomResponse
 
   return result
 }


### PR DESCRIPTION
## Description

Create an end-to-end test that first configures the node then tests convert-coin:

0. Begin genesis with a supply of `ibc/...` tokens
1. Submit a `register-convert-coin` proposal
2. Bond tokens with a validator to enable voting
3. Vote on the new proposal
4. Wait for the proposal to take effect
5. Convert the `ibc/...` token to the new ERC-20 representation
