### PR TITLE
refactor: migrate Ethermint Protobuf to latest Evmos, add account type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1954,15 +1954,36 @@
       }
     },
     "node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
-      "version": "1.0.0-20221115045553-508e19f5f375.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/1.0.0-20221115045553-508e19f5f375.1/tarball",
+      "version": "1.2.0-20221115045553-508e19f5f375.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/1.2.0-20221115045553-508e19f5f375.1/tarball",
       "dependencies": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.2.0-20211202220400-1935555c206d.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.2.0-20221020125208-34d970b699f8.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.2.0-20221025150512-783e4b5374fa.1"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
+        "@bufbuild/protobuf": "^1.2.0"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/cosmos_cosmos-proto.bufbuild_es": {
+      "version": "1.2.0-20211202220400-1935555c206d.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/1.2.0-20211202220400-1935555c206d.1/tarball",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.2.0"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.2.0-20221020125208-34d970b699f8.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/1.2.0-20221020125208-34d970b699f8.1/tarball",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.2.0"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.2.0-20221025150512-783e4b5374fa.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/1.2.0-20221025150512-783e4b5374fa.1/tarball",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.2.0"
       }
     },
     "node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
@@ -1972,31 +1993,38 @@
         "@bufbuild/protobuf": "^1.0.0"
       }
     },
-    "node_modules/@buf/evmos_ethermint.bufbuild_es": {
-      "version": "1.0.0-20221117114055-f0f1df1cd49a.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/evmos_ethermint.bufbuild_es/1.0.0-20221117114055-f0f1df1cd49a.1/tarball",
+    "node_modules/@buf/evmos_evmos.bufbuild_es": {
+      "version": "1.2.0-20230315212311-c66c6f141d04.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/evmos_evmos.bufbuild_es/1.2.0-20230315212311-c66c6f141d04.1/tarball",
       "dependencies": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.0.0-20221115045553-508e19f5f375.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.2.0-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.2.0-20221115045553-508e19f5f375.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.2.0-20221020125208-34d970b699f8.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.2.0-20221025150512-783e4b5374fa.1"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
+        "@bufbuild/protobuf": "^1.2.0"
       }
     },
-    "node_modules/@buf/evmos_evmos.bufbuild_es": {
-      "version": "1.0.0-20230131074124-0a9333a60b2d.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/evmos_evmos.bufbuild_es/1.0.0-20230131074124-0a9333a60b2d.1/tarball",
-      "dependencies": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.0.0-20221115045553-508e19f5f375.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-        "@buf/evmos_ethermint.bufbuild_es": "1.0.0-20221117114055-f0f1df1cd49a.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
-      },
+    "node_modules/@buf/evmos_evmos.bufbuild_es/node_modules/@buf/cosmos_cosmos-proto.bufbuild_es": {
+      "version": "1.2.0-20211202220400-1935555c206d.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/1.2.0-20211202220400-1935555c206d.1/tarball",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
+        "@bufbuild/protobuf": "^1.2.0"
+      }
+    },
+    "node_modules/@buf/evmos_evmos.bufbuild_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.2.0-20221020125208-34d970b699f8.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/1.2.0-20221020125208-34d970b699f8.1/tarball",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.2.0"
+      }
+    },
+    "node_modules/@buf/evmos_evmos.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.2.0-20221025150512-783e4b5374fa.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/1.2.0-20221025150512-783e4b5374fa.1/tarball",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.2.0"
       }
     },
     "node_modules/@buf/googleapis_googleapis.bufbuild_es": {
@@ -2007,9 +2035,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.0.0.tgz",
-      "integrity": "sha512-oH3jHBrZ6to8Qf4zLg7O8KqSY42kQZNBRXJRMp5uSi0mqE4L8NbyMnZHeOsbXmTb0xpptRyH11LfS+KeVhXzAA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.2.0.tgz",
+      "integrity": "sha512-MBVuQMOBHxgGnZ9XCUIi8WOy5O/T4ma3TduCRhRvndv3UDbG9cHgd8h6nOYSGyBYPEvXf1z9nTwhp8mVIDbq2g=="
     },
     "node_modules/@commitlint/cli": {
       "version": "16.3.0",
@@ -18026,6 +18054,7 @@
       "devDependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/contracts": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
         "@ethersproject/providers": "^5.7.2",
         "@ethersproject/wallet": "^5.7.0",
@@ -18104,8 +18133,7 @@
       "dependencies": {
         "@buf/cosmos_cosmos-sdk.bufbuild_es": "^1.0.0-20230125164018-54d184078b88.1",
         "@buf/cosmos_ibc.bufbuild_es": "^1.0.0-20230127093016-72d4bdec25a0.1",
-        "@buf/evmos_ethermint.bufbuild_es": "^1.0.0-20221117114055-f0f1df1cd49a.1",
-        "@buf/evmos_evmos.bufbuild_es": "^1.0.0-20230131074124-0a9333a60b2d.1",
+        "@buf/evmos_evmos.bufbuild_es": "^1.2.0-20230315212311-c66c6f141d04.1",
         "@bufbuild/protobuf": "^1.0.0",
         "@types/node": "^17.0.21",
         "link-module-alias": "^1.2.0",
@@ -19574,12 +19602,29 @@
       "requires": {}
     },
     "@buf/cosmos_cosmos-sdk.bufbuild_es": {
-      "version": "1.0.0-20221115045553-508e19f5f375.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/1.0.0-20221115045553-508e19f5f375.1/tarball",
+      "version": "1.2.0-20221115045553-508e19f5f375.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/1.2.0-20221115045553-508e19f5f375.1/tarball",
       "requires": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.2.0-20211202220400-1935555c206d.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.2.0-20221020125208-34d970b699f8.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.2.0-20221025150512-783e4b5374fa.1"
+      },
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": {
+          "version": "1.2.0-20211202220400-1935555c206d.1",
+          "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/1.2.0-20211202220400-1935555c206d.1/tarball",
+          "requires": {}
+        },
+        "@buf/cosmos_gogo-proto.bufbuild_es": {
+          "version": "1.2.0-20221020125208-34d970b699f8.1",
+          "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/1.2.0-20221020125208-34d970b699f8.1/tarball",
+          "requires": {}
+        },
+        "@buf/googleapis_googleapis.bufbuild_es": {
+          "version": "1.2.0-20221025150512-783e4b5374fa.1",
+          "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/1.2.0-20221025150512-783e4b5374fa.1/tarball",
+          "requires": {}
+        }
       }
     },
     "@buf/cosmos_gogo-proto.bufbuild_es": {
@@ -19587,25 +19632,31 @@
       "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/1.0.0-20221020125208-34d970b699f8.1/tarball",
       "requires": {}
     },
-    "@buf/evmos_ethermint.bufbuild_es": {
-      "version": "1.0.0-20221117114055-f0f1df1cd49a.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/evmos_ethermint.bufbuild_es/1.0.0-20221117114055-f0f1df1cd49a.1/tarball",
-      "requires": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.0.0-20221115045553-508e19f5f375.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
-      }
-    },
     "@buf/evmos_evmos.bufbuild_es": {
-      "version": "1.0.0-20230131074124-0a9333a60b2d.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/evmos_evmos.bufbuild_es/1.0.0-20230131074124-0a9333a60b2d.1/tarball",
+      "version": "1.2.0-20230315212311-c66c6f141d04.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/evmos_evmos.bufbuild_es/1.2.0-20230315212311-c66c6f141d04.1/tarball",
       "requires": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.0.0-20221115045553-508e19f5f375.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-        "@buf/evmos_ethermint.bufbuild_es": "1.0.0-20221117114055-f0f1df1cd49a.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.2.0-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.2.0-20221115045553-508e19f5f375.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.2.0-20221020125208-34d970b699f8.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.2.0-20221025150512-783e4b5374fa.1"
+      },
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": {
+          "version": "1.2.0-20211202220400-1935555c206d.1",
+          "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/1.2.0-20211202220400-1935555c206d.1/tarball",
+          "requires": {}
+        },
+        "@buf/cosmos_gogo-proto.bufbuild_es": {
+          "version": "1.2.0-20221020125208-34d970b699f8.1",
+          "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/1.2.0-20221020125208-34d970b699f8.1/tarball",
+          "requires": {}
+        },
+        "@buf/googleapis_googleapis.bufbuild_es": {
+          "version": "1.2.0-20221025150512-783e4b5374fa.1",
+          "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/1.2.0-20221025150512-783e4b5374fa.1/tarball",
+          "requires": {}
+        }
       }
     },
     "@buf/googleapis_googleapis.bufbuild_es": {
@@ -19614,9 +19665,9 @@
       "requires": {}
     },
     "@bufbuild/protobuf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.0.0.tgz",
-      "integrity": "sha512-oH3jHBrZ6to8Qf4zLg7O8KqSY42kQZNBRXJRMp5uSi0mqE4L8NbyMnZHeOsbXmTb0xpptRyH11LfS+KeVhXzAA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.2.0.tgz",
+      "integrity": "sha512-MBVuQMOBHxgGnZ9XCUIi8WOy5O/T4ma3TduCRhRvndv3UDbG9cHgd8h6nOYSGyBYPEvXf1z9nTwhp8mVIDbq2g=="
     },
     "@commitlint/cli": {
       "version": "16.3.0",
@@ -20506,8 +20557,7 @@
       "requires": {
         "@buf/cosmos_cosmos-sdk.bufbuild_es": "^1.0.0-20230125164018-54d184078b88.1",
         "@buf/cosmos_ibc.bufbuild_es": "^1.0.0-20230127093016-72d4bdec25a0.1",
-        "@buf/evmos_ethermint.bufbuild_es": "^1.0.0-20221117114055-f0f1df1cd49a.1",
-        "@buf/evmos_evmos.bufbuild_es": "^1.0.0-20230131074124-0a9333a60b2d.1",
+        "@buf/evmos_evmos.bufbuild_es": "^1.2.0-20230315212311-c66c6f141d04.1",
         "@bufbuild/protobuf": "^1.0.0",
         "@types/jest": "^29.4.0",
         "@types/node": "^17.0.21",
@@ -25199,6 +25249,7 @@
       "requires": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/contracts": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
         "@ethersproject/providers": "^5.7.2",
         "@ethersproject/wallet": "^5.7.0",

--- a/packages/proto/package-lock.json
+++ b/packages/proto/package-lock.json
@@ -1,21 +1,18 @@
 {
   "name": "@evmos/proto",
-  "version": "0.2.0-rc.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@evmos/proto",
-      "version": "0.2.0-rc.0",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "^1.0.0-20211202220400-1935555c206d.1",
         "@buf/cosmos_cosmos-sdk.bufbuild_es": "^1.0.0-20230125164018-54d184078b88.1",
         "@buf/cosmos_ibc.bufbuild_es": "^1.0.0-20230127093016-72d4bdec25a0.1",
-        "@buf/evmos_ethermint.bufbuild_es": "^1.0.0-20221117114055-f0f1df1cd49a.1",
-        "@buf/evmos_evmos.bufbuild_es": "^1.0.0-20230131074124-0a9333a60b2d.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "^1.0.0-20221214150216-75b4300737fb.1",
+        "@buf/evmos_evmos.bufbuild_es": "^1.2.0-20230315212311-c66c6f141d04.1",
         "@bufbuild/protobuf": "^1.0.0",
         "@types/node": "^17.0.21",
         "link-module-alias": "^1.2.0",
@@ -26,7 +23,6 @@
         "@types/jest": "^29.4.0",
         "@types/node": "^17.0.21",
         "jest": "^29.4.1",
-        "protoc-gen-ts": "^0.8.2",
         "ts-jest": "^29.0.5"
       }
     },
@@ -627,82 +623,56 @@
         "@bufbuild/protobuf": "^1.0.0"
       }
     },
-    "node_modules/@buf/evmos_ethermint.bufbuild_es": {
-      "version": "1.0.0-20221117114055-f0f1df1cd49a.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/evmos_ethermint.bufbuild_es/1.0.0-20221117114055-f0f1df1cd49a.1/tarball",
-      "dependencies": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.0.0-20221115045553-508e19f5f375.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
-      },
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
-      }
-    },
-    "node_modules/@buf/evmos_ethermint.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
-      "version": "1.0.0-20221115045553-508e19f5f375.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/1.0.0-20221115045553-508e19f5f375.1/tarball",
-      "dependencies": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
-      },
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
-      }
-    },
-    "node_modules/@buf/evmos_ethermint.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
-      "version": "1.0.0-20221025150512-783e4b5374fa.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/1.0.0-20221025150512-783e4b5374fa.1/tarball",
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
-      }
-    },
     "node_modules/@buf/evmos_evmos.bufbuild_es": {
-      "version": "1.0.0-20230131074124-0a9333a60b2d.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/evmos_evmos.bufbuild_es/1.0.0-20230131074124-0a9333a60b2d.1/tarball",
+      "version": "1.2.0-20230315212311-c66c6f141d04.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/evmos_evmos.bufbuild_es/1.2.0-20230315212311-c66c6f141d04.1/tarball",
       "dependencies": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.0.0-20221115045553-508e19f5f375.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-        "@buf/evmos_ethermint.bufbuild_es": "1.0.0-20221117114055-f0f1df1cd49a.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.2.0-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.2.0-20221115045553-508e19f5f375.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.2.0-20221020125208-34d970b699f8.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.2.0-20221025150512-783e4b5374fa.1"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
+        "@bufbuild/protobuf": "^1.2.0"
+      }
+    },
+    "node_modules/@buf/evmos_evmos.bufbuild_es/node_modules/@buf/cosmos_cosmos-proto.bufbuild_es": {
+      "version": "1.2.0-20211202220400-1935555c206d.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/1.2.0-20211202220400-1935555c206d.1/tarball",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.2.0"
       }
     },
     "node_modules/@buf/evmos_evmos.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
-      "version": "1.0.0-20221115045553-508e19f5f375.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/1.0.0-20221115045553-508e19f5f375.1/tarball",
+      "version": "1.2.0-20221115045553-508e19f5f375.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/1.2.0-20221115045553-508e19f5f375.1/tarball",
       "dependencies": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.2.0-20211202220400-1935555c206d.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.2.0-20221020125208-34d970b699f8.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.2.0-20221025150512-783e4b5374fa.1"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
+        "@bufbuild/protobuf": "^1.2.0"
       }
     },
-    "node_modules/@buf/evmos_evmos.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
-      "version": "1.0.0-20221025150512-783e4b5374fa.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/1.0.0-20221025150512-783e4b5374fa.1/tarball",
+    "node_modules/@buf/evmos_evmos.bufbuild_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.2.0-20221020125208-34d970b699f8.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/1.2.0-20221020125208-34d970b699f8.1/tarball",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
+        "@bufbuild/protobuf": "^1.2.0"
       }
     },
     "node_modules/@buf/googleapis_googleapis.bufbuild_es": {
-      "version": "1.0.0-20221214150216-75b4300737fb.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/1.0.0-20221214150216-75b4300737fb.1/tarball",
+      "version": "1.2.0-20221025150512-783e4b5374fa.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/1.2.0-20221025150512-783e4b5374fa.1/tarball",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
+        "@bufbuild/protobuf": "^1.2.0"
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.0.0.tgz",
-      "integrity": "sha512-oH3jHBrZ6to8Qf4zLg7O8KqSY42kQZNBRXJRMp5uSi0mqE4L8NbyMnZHeOsbXmTb0xpptRyH11LfS+KeVhXzAA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.2.0.tgz",
+      "integrity": "sha512-MBVuQMOBHxgGnZ9XCUIi8WOy5O/T4ma3TduCRhRvndv3UDbG9cHgd8h6nOYSGyBYPEvXf1z9nTwhp8mVIDbq2g=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -2321,13 +2291,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/google-protobuf": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
@@ -4638,23 +4601,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/protoc-gen-ts": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/protoc-gen-ts/-/protoc-gen-ts-0.8.5.tgz",
-      "integrity": "sha512-LHZ+w/+DqmdgnhPtShgqtPtdv+hJ9bAXEIqNU0kkY2bPcCVIEWz5seOv20FCw6gbKorriTGP8xgz2RsIcrRvVw==",
-      "dev": true,
-      "bin": {
-        "protoc-gen-ts": "bin/protoc-gen-ts.js"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://www.buymeacoffee.com/thesayyn"
-      },
-      "peerDependencies": {
-        "google-protobuf": "^3.13.0",
-        "typescript": ">=4"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -5750,68 +5696,46 @@
       "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ics23.bufbuild_es/1.0.0-20221207100654-55085f7c710a.1/tarball",
       "requires": {}
     },
-    "@buf/evmos_ethermint.bufbuild_es": {
-      "version": "1.0.0-20221117114055-f0f1df1cd49a.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/evmos_ethermint.bufbuild_es/1.0.0-20221117114055-f0f1df1cd49a.1/tarball",
-      "requires": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.0.0-20221115045553-508e19f5f375.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
-      },
-      "dependencies": {
-        "@buf/cosmos_cosmos-sdk.bufbuild_es": {
-          "version": "1.0.0-20221115045553-508e19f5f375.1",
-          "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/1.0.0-20221115045553-508e19f5f375.1/tarball",
-          "requires": {
-            "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-            "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-            "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
-          }
-        },
-        "@buf/googleapis_googleapis.bufbuild_es": {
-          "version": "1.0.0-20221025150512-783e4b5374fa.1",
-          "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/1.0.0-20221025150512-783e4b5374fa.1/tarball",
-          "requires": {}
-        }
-      }
-    },
     "@buf/evmos_evmos.bufbuild_es": {
-      "version": "1.0.0-20230131074124-0a9333a60b2d.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/evmos_evmos.bufbuild_es/1.0.0-20230131074124-0a9333a60b2d.1/tarball",
+      "version": "1.2.0-20230315212311-c66c6f141d04.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/evmos_evmos.bufbuild_es/1.2.0-20230315212311-c66c6f141d04.1/tarball",
       "requires": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.0.0-20221115045553-508e19f5f375.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-        "@buf/evmos_ethermint.bufbuild_es": "1.0.0-20221117114055-f0f1df1cd49a.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.2.0-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.2.0-20221115045553-508e19f5f375.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.2.0-20221020125208-34d970b699f8.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.2.0-20221025150512-783e4b5374fa.1"
       },
       "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": {
+          "version": "1.2.0-20211202220400-1935555c206d.1",
+          "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/1.2.0-20211202220400-1935555c206d.1/tarball",
+          "requires": {}
+        },
         "@buf/cosmos_cosmos-sdk.bufbuild_es": {
-          "version": "1.0.0-20221115045553-508e19f5f375.1",
-          "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/1.0.0-20221115045553-508e19f5f375.1/tarball",
+          "version": "1.2.0-20221115045553-508e19f5f375.1",
+          "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/1.2.0-20221115045553-508e19f5f375.1/tarball",
           "requires": {
-            "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-            "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-            "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221025150512-783e4b5374fa.1"
+            "@buf/cosmos_cosmos-proto.bufbuild_es": "1.2.0-20211202220400-1935555c206d.1",
+            "@buf/cosmos_gogo-proto.bufbuild_es": "1.2.0-20221020125208-34d970b699f8.1",
+            "@buf/googleapis_googleapis.bufbuild_es": "1.2.0-20221025150512-783e4b5374fa.1"
           }
         },
-        "@buf/googleapis_googleapis.bufbuild_es": {
-          "version": "1.0.0-20221025150512-783e4b5374fa.1",
-          "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/1.0.0-20221025150512-783e4b5374fa.1/tarball",
+        "@buf/cosmos_gogo-proto.bufbuild_es": {
+          "version": "1.2.0-20221020125208-34d970b699f8.1",
+          "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/1.2.0-20221020125208-34d970b699f8.1/tarball",
           "requires": {}
         }
       }
     },
     "@buf/googleapis_googleapis.bufbuild_es": {
-      "version": "1.0.0-20221214150216-75b4300737fb.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/1.0.0-20221214150216-75b4300737fb.1/tarball",
+      "version": "1.2.0-20221025150512-783e4b5374fa.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/1.2.0-20221025150512-783e4b5374fa.1/tarball",
       "requires": {}
     },
     "@bufbuild/protobuf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.0.0.tgz",
-      "integrity": "sha512-oH3jHBrZ6to8Qf4zLg7O8KqSY42kQZNBRXJRMp5uSi0mqE4L8NbyMnZHeOsbXmTb0xpptRyH11LfS+KeVhXzAA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.2.0.tgz",
+      "integrity": "sha512-MBVuQMOBHxgGnZ9XCUIi8WOy5O/T4ma3TduCRhRvndv3UDbG9cHgd8h6nOYSGyBYPEvXf1z9nTwhp8mVIDbq2g=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -7030,13 +6954,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
-    },
-    "google-protobuf": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==",
-      "dev": true,
-      "peer": true
     },
     "graceful-fs": {
       "version": "4.2.10",
@@ -8740,13 +8657,6 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
       }
-    },
-    "protoc-gen-ts": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/protoc-gen-ts/-/protoc-gen-ts-0.8.5.tgz",
-      "integrity": "sha512-LHZ+w/+DqmdgnhPtShgqtPtdv+hJ9bAXEIqNU0kkY2bPcCVIEWz5seOv20FCw6gbKorriTGP8xgz2RsIcrRvVw==",
-      "dev": true,
-      "requires": {}
     },
     "react-is": {
       "version": "18.2.0",

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -29,8 +29,7 @@
   "dependencies": {
     "@buf/cosmos_cosmos-sdk.bufbuild_es": "^1.0.0-20230125164018-54d184078b88.1",
     "@buf/cosmos_ibc.bufbuild_es": "^1.0.0-20230127093016-72d4bdec25a0.1",
-    "@buf/evmos_ethermint.bufbuild_es": "^1.0.0-20221117114055-f0f1df1cd49a.1",
-    "@buf/evmos_evmos.bufbuild_es": "^1.0.0-20230131074124-0a9333a60b2d.1",
+    "@buf/evmos_evmos.bufbuild_es": "^1.2.0-20230315212311-c66c6f141d04.1",
     "@bufbuild/protobuf": "^1.0.0",
     "@types/node": "^17.0.21",
     "link-module-alias": "^1.2.0",

--- a/packages/proto/src/proto/ethermint/crypto/keys.ts
+++ b/packages/proto/src/proto/ethermint/crypto/keys.ts
@@ -1,1 +1,1 @@
-export * from '@buf/evmos_ethermint.bufbuild_es/ethermint/crypto/v1/ethsecp256k1/keys_pb.js'
+export * from '@buf/evmos_evmos.bufbuild_es/ethermint/crypto/v1/ethsecp256k1/keys_pb.js'

--- a/packages/proto/src/proto/ethermint/evm/tx.ts
+++ b/packages/proto/src/proto/ethermint/evm/tx.ts
@@ -1,1 +1,1 @@
-export * from '@buf/evmos_ethermint.bufbuild_es/ethermint/evm/v1/tx_pb.js'
+export * from '@buf/evmos_evmos.bufbuild_es/ethermint/evm/v1/tx_pb.js'

--- a/packages/proto/src/proto/ethermint/types/account.ts
+++ b/packages/proto/src/proto/ethermint/types/account.ts
@@ -1,0 +1,1 @@
+export * from '@buf/evmos_evmos.bufbuild_es/ethermint/types/v1/account_pb.js'

--- a/packages/proto/src/proto/ethermint/types/index.ts
+++ b/packages/proto/src/proto/ethermint/types/index.ts
@@ -1,1 +1,2 @@
 export * as Web3 from './web3.js'
+export * as Account from './account.js'

--- a/packages/proto/src/proto/ethermint/types/web3.ts
+++ b/packages/proto/src/proto/ethermint/types/web3.ts
@@ -1,1 +1,1 @@
-export * from '@buf/evmos_ethermint.bufbuild_es/ethermint/types/v1/web3_pb.js'
+export * from '@buf/evmos_evmos.bufbuild_es/ethermint/types/v1/web3_pb.js'


### PR DESCRIPTION
- Upgrade `buf.build` dependency to use latest Evmos types and derive Ethermint types from there
- Re-export `EthermintAccount` type

