### PR TITLE
build: bump packages to release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## evmosjs v0.3.2
+## evmosjs v0.3.3
 
 - (proto)[#157](https://github.com/evmos/evmosjs/pull/157) Refactor to use Ethermint Protobuf types exported from Evmos
 - (proto)[#159](https://github.com/evmos/evmosjs/pull/159) Add decoding utilities useful for Stargate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,14 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## Unreleased
+## evmosjs v0.3.2
+
+- (proto)[#157](https://github.com/evmos/evmosjs/pull/157) Refactor to use Ethermint Protobuf types exported from Evmos
+- (proto)[#159](https://github.com/evmos/evmosjs/pull/159) Add decoding utilities useful for Stargate
+- (transactions)[#160](https://github.com/evmos/evmosjs/pull/160) Add memo to IBC `MsgTransfer` payload
+- (transactions)[#161](https://github.com/evmos/evmosjs/pull/161) Add `MsgCancelUnbondingDelegation` payload
+
+## evmosjs v0.3.0
 
 ### API Breaking
 

--- a/packages/eip712/package.json
+++ b/packages/eip712/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evmos/eip712",
   "description": "EIP712 transaction creator for EVMOS.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@cosmjs/proto-signing": "^0.28.13",
-    "@evmos/proto": "^0.2.0",
+    "@evmos/proto": "^0.2.1",
     "@metamask/eth-sig-util": "^4.0.1",
     "cosmjs-types": "^0.5.1",
     "link-module-alias": "^1.2.0",

--- a/packages/evmosjs/package.json
+++ b/packages/evmosjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "evmosjs",
   "description": "JS and TS libs for Evmos",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -28,10 +28,10 @@
   },
   "dependencies": {
     "@evmos/address-converter": "^0.1.9",
-    "@evmos/eip712": "^0.3.0",
-    "@evmos/proto": "^0.2.0",
+    "@evmos/eip712": "^0.3.1",
+    "@evmos/proto": "^0.2.1",
     "@evmos/provider": "^0.3.1",
-    "@evmos/transactions": "^0.3.1",
+    "@evmos/transactions": "^0.3.2",
     "link-module-alias": "^1.2.0",
     "shx": "^0.3.4"
   },

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evmos/transactions",
   "description": "Transactions generator for EVMOS",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,8 +27,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@evmos/eip712": "^0.3.0",
-    "@evmos/proto": "^0.2.0",
+    "@evmos/eip712": "^0.3.1",
+    "@evmos/proto": "^0.2.1",
     "link-module-alias": "^1.2.0",
     "shx": "^0.3.4"
   },


### PR DESCRIPTION
Release evmosjs v0.3.3

- https://github.com/evmos/evmosjs/pull/161
- https://github.com/evmos/evmosjs/pull/160
- https://github.com/evmos/evmosjs/pull/159
- https://github.com/evmos/evmosjs/pull/157
